### PR TITLE
feat: add responseType support to request method

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -335,6 +335,7 @@ export default function App() {
           Authorization: "Bearer your-token-here",
         },
         body: JSON.stringify({ test: "data" }),
+        responseType: "json", // Can be 'json', 'text', 'blob', or 'arraybuffer'
       });
 
       console.log("mTLS Request Result:", result);
@@ -360,6 +361,55 @@ export default function App() {
       addLog(`Connection error: ${error}`);
       // console.error('Connection error:', error);
       Alert.alert("Connection Error", `Failed to test connection: ${error}`);
+    }
+  };
+
+  // Test different response types
+  const testResponseTypes = async () => {
+    if (!isConfigured) {
+      Alert.alert("Error", "Please configure and store certificates first");
+      return;
+    }
+
+    try {
+      setStatus("Testing Response Types...");
+      addLog("Testing different response types");
+
+      const testUrl = "https:your-test-server.com/api/v1/test";
+
+      // Test JSON response
+      addLog("Testing JSON response type...");
+      const jsonResult = await ExpoMutualTls.request(testUrl, {
+        method: "GET",
+        responseType: "json",
+      });
+      addLog(`JSON response: ${jsonResult.body.substring(0, 100)}...`);
+
+      // Test text response
+      addLog("Testing text response type...");
+      const textResult = await ExpoMutualTls.request(testUrl, {
+        method: "GET",
+        responseType: "text",
+      });
+      addLog(`Text response: ${textResult.body.substring(0, 100)}...`);
+
+      // Test blob response (for binary data like images, PDFs)
+      addLog("Testing blob response type...");
+      const blobResult = await ExpoMutualTls.request(testUrl, {
+        method: "GET",
+        responseType: "blob",
+      });
+      addLog(`Blob response (base64): ${blobResult.body.substring(0, 50)}...`);
+
+      setStatus("Response Types Test Complete");
+      Alert.alert(
+        "Success",
+        "All response types tested successfully. Check logs for details.",
+      );
+    } catch (error) {
+      setStatus("Response Types Test Error");
+      addLog(`Response types test error: ${error}`);
+      Alert.alert("Test Error", `Failed to test response types: ${error}`);
     }
   };
 
@@ -437,6 +487,12 @@ export default function App() {
           <Button
             title="Test mTLS Connection"
             onPress={testConnection}
+            disabled={!isConfigured}
+          />
+          <View style={styles.buttonSpacer} />
+          <Button
+            title="Test Response Types"
+            onPress={testResponseTypes}
             disabled={!isConfigured}
           />
         </Group>

--- a/ios/ExpoMutualTlsModule.swift
+++ b/ios/ExpoMutualTlsModule.swift
@@ -369,21 +369,22 @@ public class ExpoMutualTlsModule: Module, @unchecked Sendable {
         guard isConfigured else {
             throw ExpoMutualTlsError.notConfigured
         }
-        
+
         guard let url = options["url"] as? String else {
             throw ExpoMutualTlsError.missingRequiredField("URL is required")
         }
-        
+
         let method = options["method"] as? String ?? "GET"
         let headers = options["headers"] as? [String: String] ?? [:]
         let bodyString = options["body"] as? String
         let bodyData = bodyString?.data(using: .utf8)
-        
+        let responseType = options["responseType"] as? String
+
         emitDebugLog(type: "request", message: "Starting mTLS request", method: method, url: url)
-        
+
         do {
-            let result = try await networkManager.executeRequest(url: url, method: method, headers: headers, body: bodyData, withMTLS: true)
-            
+            let result = try await networkManager.executeRequest(url: url, method: method, headers: headers, body: bodyData, withMTLS: true, responseType: responseType)
+
             emitDebugLog(
                 type: "request_completed",
                 message: result.success ? "Request successful" : "Request failed",
@@ -391,9 +392,9 @@ public class ExpoMutualTlsModule: Module, @unchecked Sendable {
                 url: url,
                 statusCode: result.statusCode
             )
-            
+
             return result
-            
+
         } catch {
             emitDebugLog(type: "request_error", message: "Request failed: \(error.localizedDescription)", method: method, url: url)
             throw error

--- a/src/ExpoMutualTls.types.ts
+++ b/src/ExpoMutualTls.types.ts
@@ -73,11 +73,14 @@ export type ConfigureResult = {
 
 export type StoreCertificateOptions = P12CertificateData | PemCertificateData;
 
+export type ResponseType = "json" | "blob" | "arraybuffer" | "text";
+
 export type MakeRequestOptions = {
   url: string;
   method?: string;
   headers?: Record<string, string>;
   body?: string;
+  responseType?: ResponseType;
 };
 
 export type MakeRequestResult = {


### PR DESCRIPTION
Add support for different response types in makeRequest function:
- json: returns UTF-8 text string suitable for JSON parsing
- text: returns UTF-8 text string for plain text responses
- blob: returns base64-encoded binary data for images, PDFs, etc.
- arraybuffer: returns base64-encoded binary data (identical to blob)

Changes:
- Add ResponseType type definition to ExpoMutualTls.types.ts
- Update iOS NetworkManager to process responses based on responseType
- Update Android ExpoMutualTlsModule to handle response type processing
- Add responseType parameter to makeRequest options
- Update example app with testResponseTypes() function to demonstrate usage
- Maintain backward compatibility (responseType is optional)

Both iOS and Android implementations are consistent in their handling of response types, using base64 encoding for binary data and UTF-8 decoding for text-based responses.